### PR TITLE
Fuzzy matching for the docs command

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,72 +1,78 @@
 'use strict';
 let fuzzy = require('fuzzy');
 
-let baseURL = 'https://developers.sparkpost.com/api/#/reference/'
-  , availableDocs = [
-      'inbound-domains',
-      'metrics',
-      'message-events',
-      'recipient-lists',
-      'relay-webhooks',
-      'sending-domains',
-      'smtp-api',
-      'subaccounts',
-      'substitutions-reference',
-      'suppression-list',
-      'templates',
-      'tracking-domains',
-      'transmissions',
-      'webhooks'
-  ];
+let baseURL = 'https://developers.sparkpost.com/api/#/reference/';
+let availableDocs = [
+  'inbound-domains',
+  'metrics',
+  'message-events',
+  'recipient-lists',
+  'relay-webhooks',
+  'sending-domains',
+  'smtp-api',
+  'subaccounts',
+  'substitutions-reference',
+  'suppression-list',
+  'templates',
+  'tracking-domains',
+  'transmissions',
+  'webhooks'
+];
 
 function getHelpText(botName) {
   let helpText = '';
+
   availableDocs.forEach((doc) => {
-    helpText += '`@' + botName + ' docs ' + doc + '`\n'
+    helpText += '`@' + botName + ' docs ' + doc + '`\n';
   });
   return helpText;
 }
 
+function descendingScore(a, b) {
+  if (a.score < b.score) {
+    return 1;
+  }
+  if (a.score > b.score) {
+    return -1;
+  }
+  return 0;
+}
+
 module.exports = {
-  init: function(controller, bot) {
+  init: function(controller) {
     controller.hears('^docs (.*)', 'direct_message,direct_mention', (bot, message) => {
       let target = message.match[1];
       let fuzzyResults = fuzzy.filter(target, availableDocs);
 
-      if (fuzzyResults.length == 0) {
-        bot.reply(message, "I can't help you with `" + target + "`, but if you feed me one of these I'll hook you up: " + availableDocs.join(', '));
+      if (fuzzyResults.length === 0) {
+        bot.reply(message, 'I can\'t help you with `' + target + '`, but if you feed me one of these I\'ll hook you up: ' + availableDocs.join(', '));
         return;
       } else if (fuzzyResults.length > 1) {
         // sort the results by descending score
-        fuzzyResults.sort(function (a, b) {
-          if (a.score < b.score) {
-            return 1;
-          }
-          if (a.score > b.score) {
-            return -1;
-          }
-          return 0;
-        });
+        fuzzyResults.sort(descendingScore);
 
         // matching scores means we cannot choose one result
-        if (fuzzyResults[0].score == fuzzyResults[1].score) {
-          let possibleResults = [];
-          for (let r of fuzzyResults) {
-            if (r.score == fuzzyResults[0].score) {
-              possibleResults.push(r.original);
-            }
-          }
-          bot.reply(message, "Possible docs matches: " + possibleResults.join(', '));
+        if (fuzzyResults[0].score === fuzzyResults[1].score) {
+          let possibleResults = fuzzyResults.filter(function(r) {
+            return r.score === fuzzyResults[0].score;
+          }).map(function(r) {
+            return r.original;
+          });
+
+          bot.reply(message, 'Possible `docs` matches: ' + possibleResults.join(', '));
           return;
         }
       }
 
+      /* eslint-disable camelcase */
       bot.api.chat.postMessage({
         channel: message.channel,
         text: baseURL + fuzzyResults[0].string,
         unfurl_links: false,
         as_user: true
       });
+
+      /* eslint-enable camelcase */
     });
   },
   help: {

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,12 +1,6 @@
 'use strict';
 let fuzzy = require('fuzzy');
 
-//let request = require('request')
-  //, config = require('config')
-  //, username = config.jira.username
-  //, password = config.jira.password
-  //, jiraBaseUrl = 'https://' + username + ':' + password + '@jira.int.messagesystems.com/rest/api/2';
-
 let baseURL = 'https://developers.sparkpost.com/api/#/reference/'
   , availableDocs = [
       'inbound-domains',
@@ -56,7 +50,7 @@ module.exports = {
 
         // matching scores means we cannot choose one result
         if (fuzzyResults[0].score == fuzzyResults[1].score) {
-          let possibleResults = Array();
+          let possibleResults = [];
           for (let r of fuzzyResults) {
             if (r.score == fuzzyResults[0].score) {
               possibleResults.push(r.original);

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,4 +1,5 @@
 'use strict';
+let fuzzy = require('fuzzy');
 
 //let request = require('request')
   //, config = require('config')
@@ -36,17 +37,42 @@ module.exports = {
   init: function(controller, bot) {
     controller.hears('^docs (.*)', 'direct_message,direct_mention', (bot, message) => {
       let target = message.match[1];
+      let fuzzyResults = fuzzy.filter(target, availableDocs);
 
-      if (availableDocs.indexOf(target) > -1) {
-        bot.api.chat.postMessage({
-          channel: message.channel,
-          text: baseURL + target,
-          unfurl_links: false,
-          as_user: true
-        });
-      } else {
+      if (fuzzyResults.length == 0) {
         bot.reply(message, "I can't help you with `" + target + "`, but if you feed me one of these I'll hook you up: " + availableDocs.join(', '));
+        return;
+      } else if (fuzzyResults.length > 1) {
+        // sort the results by descending score
+        fuzzyResults.sort(function (a, b) {
+          if (a.score < b.score) {
+            return 1;
+          }
+          if (a.score > b.score) {
+            return -1;
+          }
+          return 0;
+        });
+
+        // matching scores means we cannot choose one result
+        if (fuzzyResults[0].score == fuzzyResults[1].score) {
+          let possibleResults = Array();
+          for (let r of fuzzyResults) {
+            if (r.score == fuzzyResults[0].score) {
+              possibleResults.push(r.original);
+            }
+          }
+          bot.reply(message, "Possible docs matches: " + possibleResults.join(', '));
+          return;
+        }
       }
+
+      bot.api.chat.postMessage({
+        channel: message.channel,
+        text: baseURL + fuzzyResults[0].string,
+        unfurl_links: false,
+        as_user: true
+      });
     });
   },
   help: {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index",
-    "test": "eslint index.js"
+    "test": "eslint index.js lib/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/SparkPost/community-bot#readme",
   "dependencies": {
     "botkit-storage-mongo": "^1.0.2",
+    "fuzzy": "^0.1.1",
     "sk-nirvana": "^1.0.1",
     "sk-sparkpost-webhook": "^1.0.0",
     "skellington": "^0.1.0",


### PR DESCRIPTION
Being a lazy typist I'd like to be able to use shortened versions of the target strings in the docs command.

This PR uses the [fuzzy](https://www.npmjs.com/package/fuzzy) module to allow for that.

This screenshot shows the kind of output one sees:
![screen shot 2016-04-28 at 17 29 02](https://cloud.githubusercontent.com/assets/1440817/14893316/c0464d78-0d66-11e6-8fc8-0ac5f038b754.png)
