### PR TITLE
Check for an exact match before trying a fuzzy match

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -42,34 +42,44 @@ function descendingScore(a, b) {
   return 0;
 }
 
+function getPath(doc) {
+  return `${baseURL}${_.includes(introductionDocs, doc) ? 'introduction' : 'reference'}/${doc}`;
+}
+
 module.exports = {
   init: function(controller) {
     controller.hears('^docs (.*)', 'direct_message,direct_mention', (bot, message) => {
       let target = message.match[1];
-      let fuzzyResults = fuzzy.filter(target, availableDocs);
+      let path = '';
 
-      if (fuzzyResults.length === 0) {
-        bot.reply(message, 'I can\'t help you with `' + target + '`, but if you feed me one of these I\'ll hook you up: ' + availableDocs.join(', '));
-        return;
-      } else if (fuzzyResults.length > 1) {
-        // sort the results by descending score
-        fuzzyResults.sort(descendingScore);
+      // check for an exact match before doing fuzzy matching
+      if (_.includes(availableDocs, target)) {
+        path = getPath(target);
+      } else {
+        let fuzzyResults = fuzzy.filter(target, availableDocs);
 
-        // matching scores means we cannot choose one result
-        if (fuzzyResults[0].score === fuzzyResults[1].score) {
-          let possibleResults = fuzzyResults.filter(function(r) {
-            return r.score === fuzzyResults[0].score;
-          }).map(function(r) {
-            return r.original;
-          });
-
-          bot.reply(message, 'Possible `docs` matches: ' + possibleResults.join(', '));
+        if (fuzzyResults.length === 0) {
+          bot.reply(message, 'I can\'t help you with `' + target + '`, but if you feed me one of these I\'ll hook you up: ' + availableDocs.join(', '));
           return;
-        }
-      }
+        } else if (fuzzyResults.length > 1) {
+          // sort the results by descending score
+          fuzzyResults.sort(descendingScore);
 
-      let doc = fuzzyResults[0].string;
-      let path = `${baseURL}${_.includes(introductionDocs, doc) ? 'introduction' : 'reference'}/${doc}`;
+          // matching scores means we cannot choose one result
+          if (fuzzyResults[0].score === fuzzyResults[1].score) {
+            let possibleResults = fuzzyResults.filter(function(r) {
+              return r.score === fuzzyResults[0].score;
+            }).map(function(r) {
+              return r.original;
+            });
+
+            bot.reply(message, 'Possible `docs` matches: ' + possibleResults.join(', '));
+            return;
+          }
+        }
+
+        path = getPath(fuzzyResults[0].string);
+      }
 
       /* eslint-disable camelcase */
       bot.api.chat.postMessage({


### PR DESCRIPTION
I noticed [yesterday](https://sparkpost-community.slack.com/archives/community-support/p1462476048010102) that the command `@sparky docs webhooks` resulted in:

> Possible `docs` matches: relay-webhooks, webhooks

I've added an exact match check that is done before the fuzzy match to catch cases like this.

Note that the diff looks more complicated than the change really was because a block of code was indented. 
